### PR TITLE
compiler: add bytes function for coercion

### DIFF
--- a/docs/language/ExampleContracts.md
+++ b/docs/language/ExampleContracts.md
@@ -7,6 +7,7 @@ Below are some examples of contract templates written in Ivy. You can try out th
 * [LockWithPublicKeyHash](#lockwithpublickeyhash)
 * [RevealPreimage](#revealpreimage)
 * [RevealCollision](#revealcollision)
+* [RevealFixedPoint](#revealfixedpoint)
 * [LockUntil](#lockuntil)
 * [LockDelay](#lockdelay)
 * [TransferWithTimeout](#transferwithtimeout)
@@ -19,7 +20,7 @@ These contracts demonstrate the following conditions supported by Bitcoin Script
 
 * Requiring M signatures corresponding to any of N prespecified public keys (see [LockWithMultisig](#lockwithmultisig))
 
-* Checking that the cryptographic hash of a string or public key is equal to a prespecified hash (see [LockWithPublicKeyHash](#lockwithpublickeyhash), [RevealCollision](#revealcollision), [RevealPreimage](#revealpreimage))
+* Checking that the cryptographic hash of a string or public key is equal to a prespecified hash (see [LockWithPublicKeyHash](#lockwithpublickeyhash), [RevealCollision](#revealcollision), [RevealPreimage](#revealpreimage), [RevealFixedPoint](#revealfixedpoint))
 
 * Waiting until after a specified block height or block time (see [LockUntil](#lockuntil), [TransferWithTimeout](#transferwithtimeout)
 
@@ -108,6 +109,21 @@ RevealCollision pays a reward to anyone who provides a SHA1 collision—two diff
 Peter Todd used this script to [post a bounty](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2013-September/003253.html) on collisions for several hash functions. When a SHA1 collision was [found in February 2017](https://shattered.io/), someone used that collision to [claim the bounty](https://tradeblock.com/bitcoin/tx/8d31992805518fd62daa3bdd2a5c4fd2cd3054c9b3dca1d78055e9528cff6adc).
 
 As with the [RevealPreimage](#revealpreimage) contract, any attempt to spend this contract could potentially be sniped by miners.
+
+## RevealFixedPoint
+
+```
+contract RevealFixedPoint(val: Value) {
+  clause reveal(hash: Bytes) {
+    verify bytes(sha256(hash)) == hash
+    unlock val
+  }
+}
+```
+
+RevealFixedPoint is similar to [RevealCollision](#revealcollision), except the challenge is to reveal a SHA256 [fixed point](https://en.wikipedia.org/wiki/One-way_compression_function#cite_ref-8), rather than a SHA1 collision.
+
+In order to compare a SHA256 hash with its preimage, the former needs to be coerced to a bytestring, using the `bytes` function. This has no effect on script execution, but prevents the typechecker from objecting to the comparison.
 
 ## LockUntil
 

--- a/docs/language/Functions.md
+++ b/docs/language/Functions.md
@@ -16,5 +16,7 @@ The following functions and operators are available when compiling Ivy to Bitcoi
 
 * **ripemd160(preimage: (T: HashableType)) -> Ripemd160(T)**: compute the RIPEMD-160 hash of **preimage**
 
+* **bytes(item: T) -> Bytes**: coerce `item` to a bytestring (of type Bytes). This function does not have any effect on the compiled output or on script execution (since the Bitcoin Script VM treats every item as a bytestring); it only affects typechecking. (This cannot be called on an item of type Value.)
+
 * **==**, **!=**: check equality of any two values of the same type. (Note: because of certain limitations of Bitcoin Script, using these operators on Booleans is not allowed.)
 

--- a/ivy-bitcoin/package-lock.json
+++ b/ivy-bitcoin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ivy-bitcoin",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/ivy-bitcoin/package.json
+++ b/ivy-bitcoin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ivy-bitcoin",
   "description": "Compiler for Ivy, Chain's smart contract language.",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "homepage": "https://www.github.com/ivy-lang/ivy-bitcoin",
   "license": "MIT",
   "main": "lib/index.js",

--- a/ivy-bitcoin/src/btc/instructions.ts
+++ b/ivy-bitcoin/src/btc/instructions.ts
@@ -16,6 +16,7 @@ export type FunctionName =
   | "older"
   | "after"
   | "checkMultiSig"
+  | "bytes"
 
 export type Opcode = string // for now
 
@@ -52,6 +53,8 @@ export function getOpcodes(instruction: Instruction): Opcode[] {
       return ["EQUAL"]
     case "!=":
       return ["EQUAL", "NOT"]
+    case "bytes":
+      return []
   }
 }
 
@@ -78,5 +81,7 @@ export function getTypeSignature(instruction: Instruction): TypeSignature {
     case "sha1":
     case "sha256":
       throw new Error("should not call getTypeSignature on hash function")
+    case "bytes":
+      throw new Error("should not call getTypeSignature on bytes function")
   }
 }

--- a/ivy-bitcoin/src/predefined.ts
+++ b/ivy-bitcoin/src/predefined.ts
@@ -8,11 +8,12 @@ export const DEMO_ID_LIST = [
   "LockWithPublicKeyHash",
   "RevealPreimage",
   "RevealCollision",
+  "RevealFixedPoint",
   "LockUntil",
   "LockDelay",
   "TransferWithTimeout",
   "EscrowWithDelay",
-  "VaultSpend"
+  "VaultSpend",
 ]
 
 export const DEMO_CONTRACTS = {
@@ -119,6 +120,12 @@ export const DEMO_CONTRACTS = {
     verify checkSig(hotKey, sig)
     unlock val
   }
+}`,
+RevealFixedPoint: `contract RevealFixedPoint(val: Value) {
+  clause reveal(hash: Bytes) {
+    verify bytes(sha256(hash)) == hash
+    unlock val
+  }
 }`
 }
 
@@ -174,6 +181,7 @@ export const TEST_CONTRACT_ARGS = {
   TransferWithTimeout: [PublicKeys[0], PublicKeys[1], 20, 0],
   EscrowWithDelay: [...PublicKeys, 20, 0],
   VaultSpend: [PublicKeys[0], PublicKeys[1], 20, 0],
+  RevealFixedPoint: [0],
   HashOperations: [Sha256Bytes, Sha1Bytes, Ripemd160Bytes, 0]
 }
 
@@ -188,7 +196,8 @@ export const TEST_CONTRACT_CLAUSE_NAMES = {
   TransferWithTimeout: "transfer",
   EscrowWithDelay: "timeout",
   VaultSpend: "complete",
-  HashOperations: "reveal"
+  RevealFixedPoint: "reveal",
+  HashOperations: "reveal",
 }
 
 export const TEST_CONTRACT_TIMES = {
@@ -234,6 +243,7 @@ export const TEST_SPEND_ARGUMENTS = {
   VaultSpend: [
     "30440220259d47913eb5c5ff625fb29cfe571632e1bd197e53026eb6db3f335b05be6efe022033f59f4f240a098d41304f35870bb54012ff5d29a6f0d9664b23779e295f998001"
   ],
+  RevealFixedPoint: [Bytes], // this is supposed to fail
   HashOperations: [Bytes]
 }
 
@@ -283,9 +293,16 @@ export const ERRORS = {
     unlock val
   }
 }`,
-  "uses non-matching hash types": `contract LockWithPublicKeyHash(publicKeyHash: Sha256(PublicKey), val: Value) {
+"uses non-matching hash types": `contract LockWithPublicKeyHash(publicKeyHash: Sha256(PublicKey), val: Value) {
   clause spend(publicKey: PublicKey, sig: Signature) {
     verify sha1(publicKey) == publicKeyHash
+    verify checkSig(publicKey, sig)
+    unlock val
+  }
+}`,
+"passes wrong number of arguments to hash function": `contract LockWithPublicKeyHash(publicKeyHash: Sha256(PublicKey), val: Value) {
+  clause spend(publicKey: PublicKey, sig: Signature) {
+    verify sha1(publicKey, publicKey) == publicKeyHash
     verify checkSig(publicKey, sig)
     unlock val
   }

--- a/ivy-bitcoin/src/test/test.ts
+++ b/ivy-bitcoin/src/test/test.ts
@@ -78,6 +78,7 @@ describe("spend", () => {
 
 describe("fulfill", () => {
   Object.keys(TEST_SPEND_ARGUMENTS).forEach(id => {
+    if (id === "RevealFixedPoint") { return } // we know this would fail
     it("should be able to fulfill the spend transaction for " + id, () => {
       const template = compile(TEST_CASES[id]) as Template
       const instantiated = instantiate(template, TEST_CONTRACT_ARGS[id], seed)

--- a/ivy-bitcoin/src/typeCheck.ts
+++ b/ivy-bitcoin/src/typeCheck.ts
@@ -184,6 +184,9 @@ export function typeCheckExpression(expression: Expression): Type {
       const inputTypes = expression.args.map(arg => typeCheckExpression(arg))
       if (isHashFunctionName(expression.instruction)) {
         const inputType = typeCheckExpression(expression.args[0])
+        if (inputTypes.length !== 1) {
+          throw new IvyTypeError("hash function expected 1 argument, got " + inputTypes.length)
+        }
         if (
           !isHash(inputType) &&
           inputType !== "Bytes" &&
@@ -200,6 +203,17 @@ export function typeCheckExpression(expression: Expression): Type {
         }
       }
       switch (expression.instruction) {
+        case "bytes":
+          if (inputTypes.length !== 1) { 
+            throw new IvyTypeError("bytes function expected 1 argument, got " + inputTypes.length)
+          }
+          if (inputTypes[0] === "Value") {
+            throw new IvyTypeError("cannot call bytes on an item of type Value")
+          }
+          if (inputTypes[0] === "Boolean") {
+            throw new IvyTypeError("cannot call bytes on an item of type Boolean")
+          }
+          return "Bytes"
         case "==":
         case "!=":
           if (inputTypes[0] === "Boolean" || inputTypes[1] === "Boolean") {

--- a/ivy-playground/package-lock.json
+++ b/ivy-playground/package-lock.json
@@ -4586,9 +4586,9 @@
       }
     },
     "ivy-bitcoin": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/ivy-bitcoin/-/ivy-bitcoin-0.0.3.tgz",
-      "integrity": "sha512-U1zcnbHPfwMgmO4yzF/vLx9N9fEXBF20KEd7ViIUwTIQulB5DIY2LjAdstUEPYemLlrmwz2mNqZWuV2E3Xkccw==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/ivy-bitcoin/-/ivy-bitcoin-0.0.6.tgz",
+      "integrity": "sha512-O6pqLXHLRGnA6zH/V1r59YuwCUWn2up5y0FoOthVZ8y70fgViFJfh74wue8jlUfDbt0OHrROSJXexpMRGDdX2g==",
       "requires": {
         "bcoin": "github:danrobinson/bcoin#e69e52ca191b152c9f17506bffe8e998b6a70f49",
         "level-js": "2.2.4"

--- a/ivy-playground/package.json
+++ b/ivy-playground/package.json
@@ -17,7 +17,7 @@
     "brace": "^0.10.0",
     "css-loader": "^0.28.1",
     "file-loader": "~0.9.0",
-    "ivy-bitcoin": "0.0.3",
+    "ivy-bitcoin": "0.0.6",
     "json-loader": "^0.5.4",
     "moment": "^2.19.1",
     "pegjs": "^0.10.0",

--- a/ivy-playground/src/templates/util/ivymode.js
+++ b/ivy-playground/src/templates/util/ivymode.js
@@ -114,7 +114,7 @@ ace.define(
       var keywordMapper = this.createKeywordMapper(
         {
           "variable.language":
-            "checkSig|checkMultiSig|sha256|sha1|ripemd160|older|after",
+            "checkSig|checkMultiSig|sha256|sha1|ripemd160|older|after|bytes",
           keyword: "contract|clause|verify|unlock"
         },
         "identifier"


### PR DESCRIPTION
This adds a `bytes` function to Ivy, for coercing an item of any type into a string. It also adds associated documentation, tests, and an example "RevealFixedPoint" contract.

Fixes #1.