### PR TITLE
Correct/remove import camelcase

### DIFF
--- a/ivy-playground/src/app/components/index.tsx
+++ b/ivy-playground/src/app/components/index.tsx
@@ -1,5 +1,5 @@
 import NavBar from "./navbar"
-import RadioSelect from "./radioSelect"
+import RadioSelect from "./radioselect"
 import Reset from "./reset"
 import Root from "./root"
 import Section from "./section"

--- a/ivy-playground/src/contracts/components/parameters.tsx
+++ b/ivy-playground/src/contracts/components/parameters.tsx
@@ -34,7 +34,7 @@ import {
   getShowLockInputErrors
 } from "../../templates/selectors"
 
-import RadioSelect from "../../app/components/radioSelect"
+import RadioSelect from "../../app/components/radioselect"
 import {
   BlockheightTimeInput,
   BlocksDurationInput,


### PR DESCRIPTION
The imported file name that appears seems to be `radioselect` not `radioSelect`. 