### PR TITLE
docs(language/readme): fix paths to linked docs

### DIFF
--- a/docs/language/README.md
+++ b/docs/language/README.md
@@ -2,8 +2,8 @@
 
 Ivy is a smart contract language developed at [Chain](https://www.chain.com/) that can compile to Bitcoin Script. Ivy allows you to write contracts that secure Bitcoin using arbitrary combinations of conditions supported by Bitcoin Script.
 
-* [Bitcoin Script](/docs/language/BitcoinScript.md)
-* [Ivy Syntax](/docs/language/IvySyntax.md)
-* [Types](/docs/language/Types.md)
-* [Functions](/docs/language/Functions.md)
-* [Example Contracts](/docs/language/ExampleContracts.md)
+* [Bitcoin Script](BitcoinScript.md)
+* [Ivy Syntax](IvySyntax.md)
+* [Types](Types.md)
+* [Functions](Functions.md)
+* [Example Contracts](ExampleContracts.md)

--- a/docs/language/README.md
+++ b/docs/language/README.md
@@ -2,8 +2,8 @@
 
 Ivy is a smart contract language developed at [Chain](https://www.chain.com/) that can compile to Bitcoin Script. Ivy allows you to write contracts that secure Bitcoin using arbitrary combinations of conditions supported by Bitcoin Script.
 
-* [Bitcoin Script](/language/BitcoinScript.md)
-* [Ivy Syntax](/language/IvySyntax.md)
-* [Types](/language/Types.md)
-* [Functions](/language/Functions.md)
-* [Example Contracts](/language/ExampleContracts.md)
+* [Bitcoin Script](/docs/language/BitcoinScript.md)
+* [Ivy Syntax](/docs/language/IvySyntax.md)
+* [Types](/docs/language/Types.md)
+* [Functions](/docs/language/Functions.md)
+* [Example Contracts](/docs/language/ExampleContracts.md)


### PR DESCRIPTION
Links in docs/language/readme were broken. They are now corrected. 