### PR TITLE
Provide a command-line compiler (as its own npm package)

### DIFF
--- a/ivy-bitcoin/package.json
+++ b/ivy-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivy-bitcoin",
-  "description": "Compiler for Ivy, Chain's smart contract language.",
+  "description": "Compiler library for Ivy, Chain's smart contract language.",
   "version": "0.0.18",
   "homepage": "https://www.github.com/ivy-lang/ivy-bitcoin",
   "license": "MIT",

--- a/ivy-compiler/package-lock.json
+++ b/ivy-compiler/package-lock.json
@@ -1,0 +1,2822 @@
+{
+  "name": "ivy-compiler",
+  "version": "0.0.18",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/chai": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.3.tgz",
+      "integrity": "sha512-f5dXGzOJycyzSMdaXVhiBhauL4dYydXwVpavfQ1mVCaGjR56a9QfklXObUxlIY9bGTmCPHEEZ04I16BZ/8w5ww==",
+      "dev": true
+    },
+    "@types/commander": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
+      "dev": true,
+      "requires": {
+        "commander": "2.15.1"
+      }
+    },
+    "@types/mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-YeDiSEzznwZwwp766SJ6QlrTyBYUGPSIwmREHVTmktUYiT/WADdWtpt9iH0KuUSf8lZLdI4lP0X6PBzPo5//JQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "9.6.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.6.tgz",
+      "integrity": "sha512-SJe0g5cZeGNDP5sD8mIX3scb+eq8LQQZ60FXiKZHipYSeEFZ5EKml+NNMiO76F74TY4PoMWlNxF/YRY40FOvZQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "1.9.1"
+      }
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+    },
+    "chalk": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+      "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "ivy-bitcoin": {
+      "version": "file:../ivy-bitcoin",
+      "requires": {
+        "bcoin": "1.0.0-beta.15",
+        "level-js": "2.2.4"
+      },
+      "dependencies": {
+        "@types/chai": {
+          "version": "4.0.10",
+          "bundled": true
+        },
+        "@types/mocha": {
+          "version": "2.2.44",
+          "bundled": true
+        },
+        "@types/node": {
+          "version": "7.0.50",
+          "bundled": true
+        },
+        "abstract-leveldown": {
+          "version": "0.12.4",
+          "bundled": true,
+          "requires": {
+            "xtend": "3.0.0"
+          },
+          "dependencies": {
+            "xtend": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "accepts": {
+          "version": "1.3.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "mime-types": "2.1.17",
+            "negotiator": "0.6.1"
+          }
+        },
+        "after": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "anymatch": {
+          "version": "1.3.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "micromatch": "2.3.11",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.3"
+          }
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true,
+          "optional": true
+        },
+        "arraybuffer.slice": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "assertion-error": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "async-each": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "async-limiter": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "babel-cli": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "6.26.0",
+            "babel-polyfill": "6.26.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "chokidar": "1.7.0",
+            "commander": "2.12.2",
+            "convert-source-map": "1.5.1",
+            "fs-readdir-recursive": "1.1.0",
+            "glob": "7.1.2",
+            "lodash": "4.17.4",
+            "output-file-sync": "1.1.2",
+            "path-is-absolute": "1.0.1",
+            "slash": "1.0.0",
+            "source-map": "0.5.7",
+            "v8flags": "2.1.1"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.12.2",
+              "bundled": true
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "v8flags": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "user-home": "1.1.1"
+              }
+            }
+          }
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-core": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.0",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.1",
+            "debug": "2.6.8",
+            "json5": "0.5.1",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          }
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-polyfill": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.10.5"
+          },
+          "dependencies": {
+            "regenerator-runtime": {
+              "version": "0.10.5",
+              "bundled": true
+            }
+          }
+        },
+        "babel-register": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "core-js": "2.5.3",
+            "home-or-tmp": "2.0.0",
+            "lodash": "4.17.4",
+            "mkdirp": "0.5.1",
+            "source-map-support": "0.4.18"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.8",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "backo2": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base64-arraybuffer": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "base64id": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "bcoin": {
+          "version": "1.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "babel-cli": "6.26.0",
+            "babel-polyfill": "6.26.0",
+            "bn.js": "4.11.8",
+            "elliptic": "6.4.0",
+            "leveldown": "1.7.2",
+            "n64": "0.0.18",
+            "socket.io": "2.0.3",
+            "socket.io-client": "2.0.3"
+          }
+        },
+        "better-assert": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "callsite": "1.0.0"
+          }
+        },
+        "binary-extensions": {
+          "version": "1.11.0",
+          "bundled": true,
+          "optional": true
+        },
+        "bindings": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true
+        },
+        "bl": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "readable-stream": "2.3.3"
+          }
+        },
+        "blob": {
+          "version": "0.0.4",
+          "bundled": true
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "brorand": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "browser-stdout": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "callsite": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "chai": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "assertion-error": "1.0.2",
+            "check-error": "1.0.2",
+            "deep-eql": "3.0.1",
+            "get-func-name": "2.0.0",
+            "pathval": "1.1.0",
+            "type-detect": "4.0.5"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "4.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
+          }
+        },
+        "check-error": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "1.3.2",
+            "async-each": "1.0.1",
+            "fsevents": "1.1.3",
+            "glob-parent": "2.0.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "2.0.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "commander": {
+          "version": "2.9.0",
+          "bundled": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "component-bind": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "component-inherit": {
+          "version": "0.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "bundled": true,
+          "optional": true
+        },
+        "core-js": {
+          "version": "2.5.3",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-eql": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "type-detect": "4.0.5"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        },
+        "diff": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "elliptic": {
+          "version": "6.4.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "brorand": "1.1.0",
+            "hash.js": "1.1.3",
+            "hmac-drbg": "1.0.1",
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.0",
+            "minimalistic-crypto-utils": "1.0.1"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0"
+          }
+        },
+        "engine.io": {
+          "version": "3.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "accepts": "1.3.3",
+            "base64id": "1.0.0",
+            "cookie": "0.3.1",
+            "debug": "2.6.9",
+            "engine.io-parser": "2.1.1",
+            "uws": "0.14.5",
+            "ws": "3.3.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "engine.io-client": {
+          "version": "3.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "component-inherit": "0.0.3",
+            "debug": "2.6.9",
+            "engine.io-parser": "2.1.1",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "ws": "3.3.2",
+            "xmlhttprequest-ssl": "1.5.4",
+            "yeast": "0.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "engine.io-parser": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "after": "0.8.2",
+            "arraybuffer.slice": "0.0.6",
+            "base64-arraybuffer": "0.1.5",
+            "blob": "0.0.4",
+            "has-binary2": "1.0.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fill-range": "2.2.3"
+          }
+        },
+        "expand-template": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "fast-future": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "fs-readdir-recursive": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fsevents": {
+          "version": "1.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "nan": "2.8.0",
+            "node-pre-gyp": "0.6.39"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+              }
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.2.9"
+              }
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true,
+              "optional": true
+            },
+            "assert-plus": {
+              "version": "0.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true,
+              "optional": true
+            },
+            "aws-sign2": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "balanced-match": {
+              "version": "0.4.2",
+              "bundled": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "block-stream": {
+              "version": "0.0.9",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3"
+              }
+            },
+            "boom": {
+              "version": "2.10.1",
+              "bundled": true,
+              "requires": {
+                "hoek": "2.16.3"
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.7",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "0.4.2",
+                "concat-map": "0.0.1"
+              }
+            },
+            "buffer-shims": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true,
+              "optional": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "cryptiles": {
+              "version": "2.0.5",
+              "bundled": true,
+              "requires": {
+                "boom": "2.10.1"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "debug": {
+              "version": "2.6.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.4.2",
+              "bundled": true,
+              "optional": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "extsprintf": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true,
+              "optional": true
+            },
+            "form-data": {
+              "version": "2.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.15"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fstream": {
+              "version": "1.0.11",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1"
+              }
+            },
+            "fstream-ignore": {
+              "version": "1.0.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fstream": "1.0.11",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4"
+              }
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "1.1.1",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true
+            },
+            "har-schema": {
+              "version": "1.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "bundled": true,
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              }
+            },
+            "hoek": {
+              "version": "2.16.3",
+              "bundled": true
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.0",
+                "sshpk": "1.13.0"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.4",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "jodid25519": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true,
+              "optional": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsonify": "0.0.0"
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "jsprim": {
+              "version": "1.4.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.0.2",
+                "json-schema": "0.2.3",
+                "verror": "1.3.6"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "mime-db": {
+              "version": "1.27.0",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.15",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.27.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "node-pre-gyp": {
+              "version": "0.6.39",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "1.0.2",
+                "hawk": "3.1.3",
+                "mkdirp": "0.5.1",
+                "nopt": "4.0.1",
+                "npmlog": "4.1.0",
+                "rc": "1.2.1",
+                "request": "2.81.0",
+                "rimraf": "2.6.1",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "tar-pack": "3.4.0"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1.1.0",
+                "osenv": "0.1.4"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "bundled": true
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true,
+              "optional": true
+            },
+            "qs": {
+              "version": "6.4.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "0.4.2",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.2.9",
+              "bundled": true,
+              "requires": {
+                "buffer-shims": "1.0.0",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "1.0.1",
+                "util-deprecate": "1.0.2"
+              }
+            },
+            "request": {
+              "version": "2.81.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.15",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.0.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.1",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sntp": {
+              "version": "1.0.9",
+              "bundled": true,
+              "requires": {
+                "hoek": "2.16.3"
+              }
+            },
+            "sshpk": {
+              "version": "1.13.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jodid25519": "1.0.2",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.0.1"
+              }
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              }
+            },
+            "tar-pack": {
+              "version": "3.4.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "2.6.8",
+                "fstream": "1.0.11",
+                "fstream-ignore": "1.0.5",
+                "once": "1.4.0",
+                "readable-stream": "2.2.9",
+                "rimraf": "2.6.1",
+                "tar": "2.2.1",
+                "uid-number": "0.0.6"
+              }
+            },
+            "tough-cookie": {
+              "version": "2.3.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "punycode": "1.4.1"
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "5.0.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "optional": true
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "bundled": true,
+              "optional": true
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "verror": {
+              "version": "1.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "extsprintf": "1.0.2"
+              }
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "get-func-name": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "github-from-package": {
+          "version": "0.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "glob": {
+          "version": "7.1.1",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "growl": {
+          "version": "1.9.2",
+          "bundled": true
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "has-binary2": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "isarray": "2.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "has-cors": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.0"
+          }
+        },
+        "he": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "hmac-drbg": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "hash.js": "1.1.3",
+            "minimalistic-assert": "1.0.0",
+            "minimalistic-crypto-utils": "1.0.1"
+          }
+        },
+        "home-or-tmp": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "homedir-polyfill": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "parse-passwd": "1.0.0"
+          }
+        },
+        "idb-wrapper": {
+          "version": "1.7.2",
+          "bundled": true
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "optional": true
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "binary-extensions": "1.11.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "is-primitive": "2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isbuffer": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "json3": {
+          "version": "3.3.2",
+          "bundled": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "level-js": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "abstract-leveldown": "0.12.4",
+            "idb-wrapper": "1.7.2",
+            "isbuffer": "0.0.0",
+            "ltgt": "2.2.0",
+            "typedarray-to-buffer": "1.0.4",
+            "xtend": "2.1.2"
+          }
+        },
+        "leveldown": {
+          "version": "1.7.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abstract-leveldown": "2.6.3",
+            "bindings": "1.2.1",
+            "fast-future": "1.0.2",
+            "nan": "2.6.2",
+            "prebuild-install": "2.4.1"
+          },
+          "dependencies": {
+            "abstract-leveldown": {
+              "version": "2.6.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "xtend": "4.0.1"
+              }
+            },
+            "nan": {
+              "version": "2.6.2",
+              "bundled": true,
+              "optional": true
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true
+        },
+        "lodash._baseassign": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "lodash._basecopy": "3.0.1",
+            "lodash.keys": "3.1.2"
+          }
+        },
+        "lodash._basecopy": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "lodash._basecreate": {
+          "version": "3.0.3",
+          "bundled": true
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "bundled": true
+        },
+        "lodash._isiterateecall": {
+          "version": "3.0.9",
+          "bundled": true
+        },
+        "lodash.create": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "lodash._baseassign": "3.2.0",
+            "lodash._basecreate": "3.0.3",
+            "lodash._isiterateecall": "3.0.9"
+          }
+        },
+        "lodash.isarguments": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "lodash.isarray": {
+          "version": "3.0.4",
+          "bundled": true
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
+          }
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "ltgt": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "make-error": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "bundled": true,
+          "optional": true
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "minimalistic-assert": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimalistic-crypto-utils": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "mocha": {
+          "version": "3.5.3",
+          "bundled": true,
+          "requires": {
+            "browser-stdout": "1.3.0",
+            "commander": "2.9.0",
+            "debug": "2.6.8",
+            "diff": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.1",
+            "growl": "1.9.2",
+            "he": "1.1.1",
+            "json3": "3.3.2",
+            "lodash.create": "3.1.1",
+            "mkdirp": "0.5.1",
+            "supports-color": "3.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "n64": {
+          "version": "0.0.18",
+          "bundled": true
+        },
+        "nan": {
+          "version": "2.8.0",
+          "bundled": true,
+          "optional": true
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "node-abi": {
+          "version": "2.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "semver": "5.4.1"
+          }
+        },
+        "noop-logger": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "remove-trailing-separator": "1.1.0"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-component": {
+          "version": "0.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "output-file-sync": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.3",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "parse-passwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "parseqs": {
+          "version": "0.0.5",
+          "bundled": true,
+          "requires": {
+            "better-assert": "1.0.2"
+          }
+        },
+        "parseuri": {
+          "version": "0.0.5",
+          "bundled": true,
+          "requires": {
+            "better-assert": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "pathval": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "pegjs": {
+          "version": "0.10.0",
+          "bundled": true
+        },
+        "prebuild-install": {
+          "version": "2.4.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "expand-template": "1.1.0",
+            "github-from-package": "0.0.0",
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "node-abi": "2.1.2",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "os-homedir": "1.0.2",
+            "pump": "1.0.3",
+            "rc": "1.2.2",
+            "simple-get": "1.4.3",
+            "tar-fs": "1.16.0",
+            "tunnel-agent": "0.6.0",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "private": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "pump": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "1.4.0",
+            "once": "1.4.0"
+          }
+        },
+        "randomatic": {
+          "version": "1.1.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "rc": {
+          "version": "1.2.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "readdirp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.4",
+            "readable-stream": "2.3.3",
+            "set-immediate-shim": "1.0.1"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true
+        },
+        "regex-cache": {
+          "version": "0.4.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "is-equal-shallow": "0.1.3"
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "bundled": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-immediate-shim": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "simple-get": {
+          "version": "1.4.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "unzip-response": "1.0.2",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "xtend": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "socket.io": {
+          "version": "2.0.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "engine.io": "3.1.4",
+            "object-assign": "4.1.1",
+            "socket.io-adapter": "1.1.1",
+            "socket.io-client": "2.0.3",
+            "socket.io-parser": "3.1.2"
+          }
+        },
+        "socket.io-adapter": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "socket.io-client": {
+          "version": "2.0.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "backo2": "1.0.2",
+            "base64-arraybuffer": "0.1.5",
+            "component-bind": "1.0.0",
+            "component-emitter": "1.2.1",
+            "debug": "2.6.8",
+            "engine.io-client": "3.1.4",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "object-component": "0.0.3",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "socket.io-parser": "3.1.2",
+            "to-array": "0.1.4"
+          }
+        },
+        "socket.io-parser": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "debug": "2.6.8",
+            "has-binary2": "1.0.2",
+            "isarray": "2.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "bundled": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        },
+        "tar-fs": {
+          "version": "1.16.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pump": "1.0.3",
+            "tar-stream": "1.5.5"
+          }
+        },
+        "tar-stream": {
+          "version": "1.5.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "bl": "1.2.1",
+            "end-of-stream": "1.4.0",
+            "readable-stream": "2.3.3",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "xtend": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "to-array": {
+          "version": "0.1.4",
+          "bundled": true,
+          "optional": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "ts-node": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "chalk": "2.3.0",
+            "diff": "3.2.0",
+            "make-error": "1.3.0",
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "source-map-support": "0.4.18",
+            "tsconfig": "6.0.0",
+            "v8flags": "3.0.1",
+            "yn": "2.0.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "tsconfig": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "strip-bom": "3.0.0",
+            "strip-json-comments": "2.0.1"
+          }
+        },
+        "tslib": {
+          "version": "1.8.1",
+          "bundled": true
+        },
+        "tslint": {
+          "version": "5.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "builtin-modules": "1.1.1",
+            "chalk": "2.3.0",
+            "commander": "2.9.0",
+            "diff": "3.2.0",
+            "glob": "7.1.1",
+            "minimatch": "3.0.4",
+            "resolve": "1.5.0",
+            "semver": "5.4.1",
+            "tslib": "1.8.1",
+            "tsutils": "2.13.1"
+          }
+        },
+        "tslint-config-prettier": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "tsutils": {
+          "version": "2.13.1",
+          "bundled": true,
+          "requires": {
+            "tslib": "1.8.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.5",
+          "bundled": true
+        },
+        "typedarray-to-buffer": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "typescript": {
+          "version": "2.7.2",
+          "bundled": true
+        },
+        "ultron": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "unzip-response": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uws": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "v8flags": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "homedir-polyfill": "1.0.1"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "ws": {
+          "version": "3.3.2",
+          "bundled": true,
+          "requires": {
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "ultron": "1.1.1"
+          }
+        },
+        "xmlhttprequest-ssl": {
+          "version": "1.5.4",
+          "bundled": true,
+          "optional": true
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "bundled": true,
+          "requires": {
+            "object-keys": "0.4.0"
+          }
+        },
+        "yeast": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "yn": {
+          "version": "2.0.0",
+          "bundled": true
+        }
+      }
+    },
+    "make-error": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g=="
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
+      "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+      "requires": {
+        "source-map": "0.6.1"
+      }
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "requires": {
+        "has-flag": "3.0.0"
+      }
+    },
+    "ts-node": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-6.0.0.tgz",
+      "integrity": "sha512-+CQev+4J7BAUNUnW9piRzSfSZZWeFCjgUjMSgGs4+dJ2RZa86NVW9MOlP4e6/kEHTyOqdxHxcIMd7KgmY/ynVw==",
+      "requires": {
+        "arrify": "1.0.1",
+        "chalk": "2.4.0",
+        "diff": "3.5.0",
+        "make-error": "1.3.4",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.5.4",
+        "yn": "2.0.0"
+      }
+    },
+    "typescript": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
+      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw=="
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
+    }
+  }
+}

--- a/ivy-compiler/package.json
+++ b/ivy-compiler/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "ivy-compiler",
+  "version": "0.0.18",
+  "description": "Compiler command-line tool for Ivy, Chain's smart contract language.",
+  "main": "src/main.js",
+  "scripts": {
+    "run": "./node_modules/ts-node/dist/bin.js src/main.ts",
+    "build": "tsc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ivy-lang/ivy-bitcoin.git"
+  },
+  "author": "Andres G. Aragoneses",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ivy-lang/ivy-bitcoin/issues"
+  },
+  "dependencies": {
+    "commander": "^2.15.1",
+    "ivy-bitcoin": "../ivy-bitcoin",
+    "ts-node": "^6.0.0",
+    "typescript": "^2.8.3"
+  },
+  "homepage": "https://github.com/ivy-lang/ivy-bitcoin#readme",
+  "devDependencies": {
+    "@types/chai": "^4.1.3",
+    "@types/commander": "^2.12.2",
+    "@types/mocha": "^5.2.0",
+    "@types/node": "^9.6.6"
+  }
+}

--- a/ivy-compiler/src/main.ts
+++ b/ivy-compiler/src/main.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import commander = require("commander");
+import fs = require('fs');
+import ivy = require('ivy-bitcoin');
+
+let fileToCompile = null;
+
+const cli =
+    commander
+        .version("1.0.0")
+        .description("Ivy-bitcoin language compiler")
+        .usage('[options] <file>')
+        .arguments('<file>')
+        .action(function(file) {
+            if (file != null)
+                fileToCompile = file;
+        })
+        .parse(process.argv);
+
+let defaultOutputExtension = ".tpl";
+
+if (fileToCompile == null) {
+    console.log ("Please provide at least one file name");
+    process.exit(1);
+} else if (!(fs.existsSync(fileToCompile))) {
+    console.log ("File doesn't exist");
+    process.exit(2);
+} else if (fs.existsSync(fileToCompile + defaultOutputExtension)) {
+    console.log (fileToCompile + defaultOutputExtension + " already exists.");
+    process.exit(3);
+} else {
+    let fileContents = fs.readFileSync(fileToCompile,'utf8');
+    let compilationResult = ivy.compile(fileContents);
+    if (compilationResult.type == "compilerError") {
+        console.log(compilationResult.message);
+        process.exit(4);
+    } else {
+        fs.writeFile(fileToCompile + defaultOutputExtension,
+                     compilationResult.instructions.join(" "),
+                     function(err) {
+            if (err)
+                return console.error(err);
+        });
+    }
+}

--- a/ivy-compiler/tsconfig.json
+++ b/ivy-compiler/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "alwaysStrict": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "lib": ["es2015"],
+    "types": ["node", "mocha", "chai"],
+    "target": "es6",
+    "moduleResolution": "node",
+    "module": "commonjs",
+    "outDir": "lib",
+    "sourceMap": true,
+    "declaration": true,
+    "rootDirs": ["src", "test"]
+  }
+}


### PR DESCRIPTION
Input files can be in any extension, and the
output will just be `sameFileName.tpl`.

NOTE: chai and mocha were added as deps because otherwise it
would throw:

$ ./node_modules/ts-node/dist/bin.js src/main.ts

/Users/andres/Documents/Code/ivy-bitcoin/ivy-compiler/node_modules/ts-node/src/index.ts:329
        throw new TSError(formatDiagnostics(diagnosticList, cwd, ts, lineOffset))
              ^
TSError: ⨯ Unable to compile TypeScript
Cannot find type definition file for 'chai'. (2688)
Cannot find type definition file for 'mocha'. (2688)
    at getOutput (/Users/andres/Documents/Code/ivy-bitcoin/ivy-compiler/node_modules/ts-node/src/index.ts:329:15)
    at Object.compile (/Users/andres/Documents/Code/ivy-bitcoin/ivy-compiler/node_modules/ts-node/src/index.ts:515:11)
    at Module.m._compile (/Users/andres/Documents/Code/ivy-bitcoin/ivy-compiler/node_modules/ts-node/src/index.ts:402:43)
    at Module._extensions..js (module.js:646:10)
    at Object.require.extensions.(anonymous function) [as .ts] (/Users/andres/Documents/Code/ivy-bitcoin/ivy-compiler/node_modules/ts-node/src/index.ts:405:12)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Function.Module.runMain (module.js:676:10)
    at Object.<anonymous> (/Users/andres/Documents/Code/ivy-bitcoin/ivy-compiler/node_modules/ts-node/src/bin.ts:145:12)